### PR TITLE
[Bug: 768] FX CLI: Separate create, cert gen commands

### DIFF
--- a/openfl/interface/collaborator.py
+++ b/openfl/interface/collaborator.py
@@ -60,6 +60,24 @@ def start_(plan, collaborator_name, data_config, secure):
 
     plan.get_collaborator(collaborator_name).run()
 
+@collaborator.command(name='create')
+@option('-n', '--collaborator_name', required=True,
+        help='The certified common name of the collaborator')
+@option('-d', '--data_path',
+        help='The data path to be associated with the collaborator')
+@option('-s', '--silent', help='Do not prompt', is_flag=True)
+def create_(collaborator_name, data_path, silent):
+    """Creates a user for an experiment."""
+    if data_path and is_directory_traversal(data_path):
+        echo('Data path is out of the openfl workspace scope.')
+        sys.exit(1)
+
+    common_name = f'{collaborator_name}'.lower()
+    subject_alternative_name = f'DNS:{common_name}'
+    file_name = f'col_{common_name}'
+
+    # TODO: There should be some association with the plan made here as well
+    register_data_path(common_name, data_path=data_path, silent=silent)
 
 def register_data_path(collaborator_name, data_path=None, silent=False):
     """Register dataset path in the plan/data.yaml file.
@@ -103,30 +121,24 @@ def register_data_path(collaborator_name, data_path=None, silent=False):
     d[collaborator_name] = dir_path
 
     # Write the data.yaml
-    with open(data_yaml, 'w', encoding='utf-8') as f:
-        for key, val in d.items():
-            f.write(f'{key}{separator}{val}\n')
-
+    if isfile(data_yaml):
+        with open(data_yaml, 'w', encoding='utf-8') as f:
+            for key, val in d.items():
+                f.write(f'{key}{separator}{val}\n')
 
 @collaborator.command(name='generate-cert-request')
 @option('-n', '--collaborator_name', required=True,
         help='The certified common name of the collaborator')
-@option('-d', '--data_path',
-        help='The data path to be associated with the collaborator')
 @option('-s', '--silent', help='Do not prompt', is_flag=True)
 @option('-x', '--skip-package',
         help='Do not package the certificate signing request for export',
         is_flag=True)
 def generate_cert_request_(collaborator_name,
-                           data_path, silent, skip_package):
+                           silent, skip_package):
     """Generate certificate request for the collaborator."""
-    if data_path and is_directory_traversal(data_path):
-        echo('Data path is out of the openfl workspace scope.')
-        sys.exit(1)
-    generate_cert_request(collaborator_name, data_path, silent, skip_package)
+    generate_cert_request(collaborator_name, silent, skip_package)
 
-
-def generate_cert_request(collaborator_name, data_path, silent, skip_package):
+def generate_cert_request(collaborator_name, silent, skip_package):
     """
     Create collaborator certificate key pair.
 
@@ -191,10 +203,6 @@ def generate_cert_request(collaborator_name, data_path, silent, skip_package):
              f' request created')
         echo('This file should be sent to the certificate authority'
              ' (typically hosted by the aggregator) for signing')
-
-    # TODO: There should be some association with the plan made here as well
-    register_data_path(common_name, data_path=data_path, silent=silent)
-
 
 def find_certificate_name(file_name):
     """Parse the collaborator name."""


### PR DESCRIPTION
This change separates existing command
"fx collaborator.py generate-cert-request" command into two commands.
"fx collaborator create -n {NAME} -d {DATA_PATH: optional}". "fx collaborator generate-cert-request -n {NAME}".

Fixes #768